### PR TITLE
Error message if vdi file already exists

### DIFF
--- a/create_cluster/cluster.sh
+++ b/create_cluster/cluster.sh
@@ -86,6 +86,8 @@ if [ $PXE_COUNT > 0 ]
             VBoxManage modifyvm $vmName --boot1 disk --boot2 net
 
             VBoxManage startvm $vmName --type headless;
+        else
+            echo "$vmName.vdi already exists, remove file to re-create. Skipping."
         fi
       done
 fi


### PR DESCRIPTION
I ran into an issue where this would quietly fail if there were still vdi files from a previous install. This makes that easier to track down.